### PR TITLE
Windows Sensor installer fix. Removing failing dispose() statement.

### DIFF
--- a/Agent-Install-Examples/powershell/sensor_install.ps1
+++ b/Agent-Install-Examples/powershell/sensor_install.ps1
@@ -123,9 +123,10 @@ begin {
                 throw $_
             } finally {
                 $this.WaitRetry($Response)
-                if ($Response) {
-                    $Response.Dispose()
-                }
+                # JSH - Dispose method is not available when UseBasicParsing is enabled
+                # if ($Response) {
+                #     $Response.Dispose()
+                # }
             }
             return $Output
         }


### PR DESCRIPTION
Removes the call to $Response.Dispose() which is no longer available now that -UseBasicParsing has been enabled.

Closes #74.
