### PR TITLE
Specifying TLS 1.2 for SecurityProtocol on sensor installer download

### DIFF
--- a/Agent-Install-Examples/powershell/sensor_install.ps1
+++ b/Agent-Install-Examples/powershell/sensor_install.ps1
@@ -123,9 +123,10 @@ begin {
                 throw $_
             } finally {
                 $this.WaitRetry($Response)
-                if ($Response) {
-                    $Response.Dispose()
-                }
+                # JSH - Dispose method is not available when UseBasicParsing is enabled
+                # if ($Response) {
+                #     $Response.Dispose()
+                # }
             }
             return $Output
         }

--- a/Network-Firewall/cloudformation/network-firewall-demo.yaml
+++ b/Network-Firewall/cloudformation/network-firewall-demo.yaml
@@ -497,6 +497,7 @@ Resources:
       UserData:
         'Fn::Base64': !Sub |
           <powershell>
+          [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
           $client = new-object System.Net.WebClient
           $client.DownloadFile("https://raw.githubusercontent.com/CrowdStrike/Cloud-AWS/master/Agent-Install-Examples/powershell/sensor_install.ps1","C:\Windows\Temp\sensor.ps1")
           C:\Windows\Temp\sensor.ps1 ${FalconClientId} ${FalconSecret}


### PR DESCRIPTION
This PR updates network-firewall-demo.yaml to use TLS 1.2 to pull down the sensor installation PowerShell script.