### PR TITLE
update ecr "describe-repositories" example

### DIFF
--- a/Container Security/eks-implementation-guide.md
+++ b/Container Security/eks-implementation-guide.md
@@ -178,7 +178,7 @@ Various command-line utilities are required for this demo. These command line to
    ```
  - Note for existing ECR registries the `repositoryUri` can be found with the following command.
    ```
-   $ aws ecr describe-repositories
+   $ aws ecr describe-repositories --region $CLOUD_REGION
    ```
 
  - Push Falcon Container image to your newly created repository


### PR DESCRIPTION
Before change:
```
# aws ecr describe-repositories 
You must specify a region. You can also configure your region by running "aws configure".
```

Defining the --region helps improve docs by not assuming people have anything setup (eg was configure)