### PR TITLE
Add dependabot scanning

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,8 @@
+---
+version: 2
+updates:
+  - package-ecosystem: pip
+    directory: "/"
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 10


### PR DESCRIPTION
Dependabot is enabled in the repo but the scanning workflow has not yet been implemented.