### PR TITLE
Security Hub Integration: Set debugging default to disabled in Terraform example

### DIFF
--- a/Security-Hub/terraform/lambda-function.tf
+++ b/Security-Hub/terraform/lambda-function.tf
@@ -112,7 +112,7 @@ resource "aws_lambda_function" "sechub_example_lambda" {
 
   environment {
       variables = {
-          DEBUG = "True"
+          DEBUG = "False"
           CONFIRM_INSTANCES = "True"
       }
   }


### PR DESCRIPTION
This update sets the debug flag to `False` for the Lambda function in our Terraform example. Closes #134.