### PR TITLE
Use SecureString in Parameter Store

### DIFF
--- a/Agent-Install-Examples/bash/API-download/install.sh
+++ b/Agent-Install-Examples/bash/API-download/install.sh
@@ -179,7 +179,7 @@ aws_ssm_parameter() {
     security_token="$(echo "$_security_credentials" | grep Token | sed -e 's/  "Token" : "//' -e 's/",$//')"
     datetime=$(date -u +"%Y%m%dT%H%M%SZ")
     date=$(date -u +"%Y%m%d")
-    request_data='{"Names":["'"${param_name}"'"]}'
+    request_data='{"Names":["'"${param_name}"'"],"WithDecryption":"true"}'
     request_data_dgst=$(echo -n "$request_data" | openssl dgst -sha256 | awk -F' ' '{print $2}')
     request_dgst=$(
         cat <<EOF | head -c -1 | openssl dgst -sha256 | awk -F' ' '{print $2}'

--- a/Agent-Install-Examples/bash/API-download/install.sh
+++ b/Agent-Install-Examples/bash/API-download/install.sh
@@ -32,7 +32,7 @@ main() {
 }
 
 cs_sensor_register() {
-    /opt/CrowdStrike/falconctl -s --cid="${cs_falcon_cid}"
+    /opt/CrowdStrike/falconctl -s -f --cid="${cs_falcon_cid}"
 }
 
 cs_sensor_restart() {


### PR DESCRIPTION
We don't want to store our API secrets in plaintext in the SSM Parameter Store. This change allows the parameters to be decrypted and used to generate the auth token for the Crowdstrike API. We also added the -f flag to the restart command so that the CID could be passed correctly