### PR TITLE
Fix incorrect role, add new mappings

### DIFF
--- a/Discover-for-Cloud-Templates/AWS/cloudformation-templates/additional-account-existing-trail/additional_account_existing_trail_v2.yaml
+++ b/Discover-for-Cloud-Templates/AWS/cloudformation-templates/additional-account-existing-trail/additional_account_existing_trail_v2.yaml
@@ -18,26 +18,18 @@ Metadata:
       - Label:
           default: Logging Account.
         Parameters:
-          - LogArchiveBucketName
-
+          - LogArchiveAccount
 
     ParameterLabels:
       CrowdStrikeCloud:
         default: The CrowdStrike Cloud your CID is hosted in
       LogArchiveAccount:
         default: Log archive account number
-      LogArchiveBucketName:
-        default: Cloudtrail log bucket created by Control Tower
       RoleName:
-        default: Default IAM Role (Can be modified)
+        default: Default IAM Role Name (Can be modified)
       ExternalID:
         default: External ID Enter 6 or more characters alphanumeric without white space
 
-
-Outputs:
-  RoleARN:
-    Description: The ARN of the role that can be assumed by Crowdstrike Discover.
-    Value: !GetAtt 'S3AccessiamRole.Arn'
 
 Mappings:
   S3perRegion:
@@ -106,44 +98,17 @@ Parameters:
     Type: String
     NoEcho: 'true'
 
-  LogArchiveBucketName:
-    Type: String
-    Description: Log Archive Bucket Name
-
   LogArchiveBucketRegion:
     Type: String
     Description: The Region where the log archive bucket is hosted
 
+  LogArchiveAccount:
+    Description: The account number of the account containing the cloudtrail log bucket
+    Type: String
+
 Resources:
 
-  launchLambdaRole:
-    Type: AWS::IAM::Role
-    Properties:
-      RoleName: LambdaRoleToCaptureEvents
-      AssumeRolePolicyDocument:
-        Version: '2012-10-17'
-        Statement:
-          - Effect: Allow
-            Principal:
-              Service: lambda.amazonaws.com
-            Action: sts:AssumeRole
-            Condition: {}
-      Path: /
-      Policies:
-        - PolicyName: s3putbucket
-          PolicyDocument:
-            Version: '2012-10-17'
-            Statement:
-              Sid: VisualEditor1
-              Effect: Allow
-              Action:
-                - s3:PutBucketNotification
-              Resource: !Join
-                - ''
-                - - 'arn:aws:s3:::'
-                  - !Ref LogArchiveBucketName
-      ManagedPolicyArns:
-        - arn:aws:iam::aws:policy/AWSLambdaExecute
+
 
   lambdaLayer:
     Type: AWS::Lambda::LayerVersion
@@ -155,43 +120,8 @@ Resources:
         S3Key: falconpy-layer.zip
       Description: Layer for requests package
       LayerName: falconpy-package
-  AddNotificationToBucket:
-    DependsOn:
-      - launchLambdaRole
-    Type: AWS::Lambda::Function
-    Properties:
-      Code:
-        S3Bucket: !FindInMap [ S3perRegion, !Ref "AWS::Region", NAME ]
-        S3Key: add_S3_notification.zip
-      Layers:
-        - !Ref lambdaLayer
-      Handler: add_S3_notification.lambda_handler
-      MemorySize: 128
 
-      Role: !GetAtt launchLambdaRole.Arn
-      Runtime: python3.7
-      Timeout: 60
-
-  TriggerAddNotificationLambda:
-    Type: 'Custom::TriggerLambda'
-    DependsOn: AddNotificationToBucket
-    Properties:
-      FalconSecret: !Ref FalconSecret
-      FalconClientId: !Ref FalconClientId
-      log_archive_acct: !Ref AWS::AccountId
-      region: !Ref AWS::Region
-      log_archive_bucket: !Ref LogArchiveBucketName
-      crwd_topic_arn: !Join
-          - ''
-          - - 'arn:aws:sns:'
-            - !Ref 'AWS::Region'
-            - !FindInMap [ CSCloud, !Ref CrowdStrikeCloud, SNSTopic ]
-      ServiceToken: !GetAtt
-        - AddNotificationToBucket
-        - Arn
-
-
-  S3AccessiamRole:
+  DiscoverAccessiamRole:
     Type: AWS::IAM::Role
     Properties:
       RoleName: !Ref 'RoleName'
@@ -212,26 +142,6 @@ Resources:
             Sid: ''
         Version: '2012-10-17'
       Path: /
-  iamPolicyCloudTrailS3Access:
-    Type: AWS::IAM::Policy
-    Properties:
-      PolicyName: ReadS3CloudTrailFiles
-      PolicyDocument:
-        Statement:
-          - Action:
-              - s3:GetObject
-            Effect: Allow
-            Resource:
-              - !Join
-                - ''
-                - - 'arn:aws:s3:::'
-                  - !Ref 'LogArchiveBucketName'
-            Sid: ''
-        Version: '2012-10-17'
-      Roles:
-        - !Ref 'S3AccessiamRole'
-    DependsOn:
-      - S3AccessiamRole
   iamPolicyDescribeAccess:
     Type: AWS::IAM::Policy
     Properties:
@@ -254,8 +164,8 @@ Resources:
             Sid: ''
         Version: '2012-10-17'
       Roles:
-        - !Ref 'S3AccessiamRole'
-    DependsOn: S3AccessiamRole
+        - !Ref 'DiscoverAccessiamRole'
+    DependsOn: DiscoverAccessiamRole
 
   RegisterAcctLambdaRole:
     Type: AWS::IAM::Role
@@ -296,9 +206,9 @@ Resources:
         Variables:
           CrowdStrikeCloud: !Ref CrowdStrikeCloud
 
-          central_s3_bucket_account: !Ref AWS::AccountId
+          central_s3_bucket_account: !Ref LogArchiveAccount
           cloudtrail_bucket_region: !Ref LogArchiveBucketRegion
-          iam_role_arn: !GetAtt "S3AccessiamRole.Arn"
+          iam_role_arn: !GetAtt "DiscoverAccessiamRole.Arn"
           CSAccountNumber: !FindInMap [ CSCloud, !Ref CrowdStrikeCloud, CSAccountNumber ]
           CSAssumingRoleName: !FindInMap [ CSCloud, !Ref CrowdStrikeCloud, CSAssumingRoleName ]
           LocalAccount: !Ref AWS::AccountId


### PR DESCRIPTION
This PR resolves a role issue with `ct_crowdstrike_log_archive_accountv2.yaml` (Control Tower) and adds a new version of the `additional_account_existing_trail_v2.yaml` template. (Discover for Cloud Templates).