### PR TITLE
Added IMDSv2 support to install.sh for metadata retrieval

### DIFF
--- a/Agent-Install-Examples/bash/API-download/install.sh
+++ b/Agent-Install-Examples/bash/API-download/install.sh
@@ -19,6 +19,7 @@ EOF
 
 
 CS_API_BASE=${CS_API_BASE:-api.crowdstrike.com}
+MTOKEN=`curl -X PUT "http://169.254.169.254/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 21600"`
 
 main() {
     if [ -n "$1" ]; then
@@ -172,8 +173,8 @@ aws_ssm_parameter() {
     }
 
     api_endpoint="AmazonSSM.GetParameters"
-    iam_role="$(curl -s http://169.254.169.254/latest/meta-data/iam/security-credentials/)"
-    _security_credentials=$(curl -s "http://169.254.169.254/latest/meta-data/iam/security-credentials/$iam_role")
+    iam_role=`curl -H "X-aws-ec2-metadata-token: $MTOKEN" -v http://169.254.169.254/latest/meta-data/iam/security-credentials`
+    _security_credentials=`curl -H "X-aws-ec2-metadata-token: $MTOKEN" -v http://169.254.169.254/latest/meta-data/iam/security-credentials/$iam_role`
     access_key_id="$(echo "$_security_credentials" | grep AccessKeyId | sed -e 's/  "AccessKeyId" : "//' -e 's/",$//')"
     access_key_secret="$(echo "$_security_credentials" | grep SecretAccessKey | sed -e 's/  "SecretAccessKey" : "//' -e 's/",$//')"
     security_token="$(echo "$_security_credentials" | grep Token | sed -e 's/  "Token" : "//' -e 's/",$//')"
@@ -358,7 +359,7 @@ cs_os_version=$(
 )
 
 aws_my_region=$(
-    curl -s http://169.254.169.254/latest/meta-data/placement/availability-zone | sed s/.$//
+      curl -H "X-aws-ec2-metadata-token: $MTOKEN" -v http://169.254.169.254/latest/meta-data/placement/availability-zone | sed s/.$//
 )
 
 cs_falcon_client_id=$(


### PR DESCRIPTION
Since IMDSv2 provides an additional layer of security by requiring a session token, it has become more common practice to set EC2 instance metadata options to 'token required'.  Our organization's standard is IMDSv2 for metadata retrieval, and the changes in install.sh allow the Falcon agent to install and register successfully.