### PR TITLE
Update AWS PrivateLink documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,17 +1,18 @@
 ![](https://raw.githubusercontent.com/CrowdStrike/falconpy/main/docs/asset/cs-logo.png)
 
-
 ## AWS Service Integrations
+
 | Integration Name | Description |
 |:-|:-|
 | [AWS Control Tower with CrowdStrike Discover for Cloud and Containers](Control-Tower/README.md) | Configure AWS Control Tower to register new AWS accounts with CrowdStrike Discover for Cloud and Containers. |
 | [AWS Control Tower with CrowdStrike Horizon](Control-Tower-For-Horizon/README.md) | Configure AWS Control Tower to register new AWS accounts with CrowdStrike Horizon. |
 | [AWS Network Firewall with CrowdStrike Threat Intelligence](Network-Firewall/README.md) | Build capabilities such as automated blocking of malicious domains (via AWS Network Firewall) based on CrowdStrike detection alerts, or perform threat hunting derived from CrowdStrike domain-based Indicators of Activity (IOAs). |
-| [AWS Private Link with CrowdStrike Sensor Proxy](aws-privatelink/README.md) | Utilize AWS PrivateLink to provide provide private connectivity between your CrowdStrike Falcon protected workloads and the CrowdStrike cloud. |
+| [AWS PrivateLink with CrowdStrike Sensor Proxy](aws-privatelink/README.md) | Leverage AWS PrivateLink to provide private connectivity between your CrowdStrike-protected workloads and the CrowdStrike cloud. |
 | [AWS Security Hub with CrowdStrike Event Streams API](Falcon-Integration-Gateway/README.md) | The Falcon Integration Gateway publishes detections identified by CrowdStrike Falcon for instances residing within Amazon Web Services (AWS) to AWS Security Hub. |
 | [AWS S3 Protected Bucket with CrowdStrike Quick Scan API](s3-bucket-protection) | S3 Bucket Protection secures your AWS storage buckets by scanning files as they are uploaded to the bucket using the CrowdStrike Quick Scan API. |
 
 ## CrowdStrike Sensor Automation
+
 | Integration Name | Description |
 |:-|:-|
 | [AWS Autoscale Groups for Auto Register/Deregister](Agent-Install-Examples/Cloudformation/autoscale/README.md) | Utilize AWS Autoscale Groups to install the CrowdStrike Falcon Sensor during virtual machine initialization, and AWS Autoscale Lifecycle hooks to deregister the instance with CrowdStrike upon virtual machine termination. |

--- a/aws-privatelink/README.md
+++ b/aws-privatelink/README.md
@@ -10,24 +10,24 @@ By leveraging AWS PrivateLink, you can establish private connectivity between th
 
 #### Falcon US-1
 
-| DNS Name                  | Service Name    | VPC Endpoint Service Name                               | AWS Region |
-|---------------------------|-----------------|---------------------------------------------------------|------------|
-| ts01-b.cloudsink.net      | Sensor Proxy    | com.amazonaws.vpce.us-west-1.vpce-svc-08744dea97b26db5d | us-west-1  |
-| lfodown01-b.cloudsink.net | Download Server | com.amazonaws.vpce.us-west-1.vpce-svc-0f9d8ca86ddcb7106 | us-west-1  |
+| DNS Name                  | Service Name    | VPC Endpoint Service Name                               | AWS Region | Availability Zones  |
+|---------------------------|-----------------|---------------------------------------------------------|------------|---------------------|
+| ts01-b.cloudsink.net      | Sensor Proxy    | com.amazonaws.vpce.us-west-1.vpce-svc-08744dea97b26db5d | us-west-1  | usw1-az1 & usw1-az3 |
+| lfodown01-b.cloudsink.net | Download Server | com.amazonaws.vpce.us-west-1.vpce-svc-0f9d8ca86ddcb7106 | us-west-1  | usw1-az1 & usw1-az3 |
 
 #### Falcon US-2
 
-| DNS Name                             | Service Name    | VPC Endpoint Service Name                               | AWS Region |
-|--------------------------------------|-----------------|---------------------------------------------------------|------------|
-| ts01-gyr-maverick.cloudsink.net      | Sensor Proxy    | com.amazonaws.vpce.us-west-2.vpce-svc-08a5bb05d337fd834 | us-west-2  |
-| lfodown01-gyr-maverick.cloudsink.net | Download Server | com.amazonaws.vpce.us-west-2.vpce-svc-0e11def2d8620ae74 | us-west-2  |
+| DNS Name                             | Service Name    | VPC Endpoint Service Name                               | AWS Region | Availability Zones  |
+|--------------------------------------|-----------------|---------------------------------------------------------|------------|---------------------|
+| ts01-gyr-maverick.cloudsink.net      | Sensor Proxy    | com.amazonaws.vpce.us-west-2.vpce-svc-08a5bb05d337fd834 | us-west-2  | usw2-az1 & usw2-az2 |
+| lfodown01-gyr-maverick.cloudsink.net | Download Server | com.amazonaws.vpce.us-west-2.vpce-svc-0e11def2d8620ae74 | us-west-2  | usw2-az1 & usw2-az2 |
 
 #### Falcon EU-1
 
-| DNS Name                             | Service Name    | VPC Endpoint Service Name                                 | AWS Region   |
-|--------------------------------------|-----------------|-----------------------------------------------------------|--------------|
-| ts01-lanner-lion.cloudsink.net       | Sensor Proxy    | com.amazonaws.vpce.eu-central1.vpce-svc-0eb7b6ca4b7271385 | eu-central-1 |
-| lfodown01-lanner-lion. cloudsink.net | Download Server | com.amazonaws.vpce.eu-central1.vpce-svc-0340142b9ab8fc564 | eu-central-1 |
+| DNS Name                             | Service Name    | VPC Endpoint Service Name                                 | AWS Region   | Availability Zones  |
+|--------------------------------------|-----------------|-----------------------------------------------------------|--------------|---------------------|
+| ts01-lanner-lion.cloudsink.net       | Sensor Proxy    | com.amazonaws.vpce.eu-central1.vpce-svc-0eb7b6ca4b7271385 | eu-central-1 | euc1-az1 & euc1-az2 |
+| lfodown01-lanner-lion. cloudsink.net | Download Server | com.amazonaws.vpce.eu-central1.vpce-svc-0340142b9ab8fc564 | eu-central-1 | euc1-az1 & euc1-az2 |
 
 ## Quick Start Overview
 

--- a/aws-privatelink/README.md
+++ b/aws-privatelink/README.md
@@ -1,41 +1,67 @@
-*Utilize AWS PrivateLink to provide provide private connectivity between your CrowdStrike Falcon protected workloads and the CrowdStrike cloud.*
+# Leverage AWS PrivateLink to provide private connectivity between your CrowdStrike-protected workloads and the CrowdStrike cloud
+
 ---
 
 ## Overview
-Utilizing AWS Private Link, it is possible to establish private connectivity between the CrowdStrike Falcon Sensor (running inside your workloads) and the CrowdStrike Cloud. 
 
-Additionally, API calls to the CrowdStrike Cloud are also routed through AWS Private Link (for example, to download the Falcon sensor).
+By leveraging AWS PrivateLink, you can establish private connectivity between the CrowdStrike Falcon Sensor (running inside your workloads) and the CrowdStrike cloud. Additionally, all API calls to the CrowdStrike cloud are routed through AWS PrivateLink  e.g., (download sensor, get host details, etc.)
+
+### DNS, VPC Endpoints, and Region Metadata
+
+#### Falcon US-1
+
+| DNS Name                  | Service Name    | VPC Endpoint Service Name                               | AWS Region |
+|---------------------------|-----------------|---------------------------------------------------------|------------|
+| ts01-b.cloudsink.net      | Sensor Proxy    | com.amazonaws.vpce.us-west-1.vpce-svc-08744dea97b26db5d | us-west-1  |
+| lfodown01-b.cloudsink.net | Download Server | com.amazonaws.vpce.us-west-1.vpce-svc-0f9d8ca86ddcb7106 | us-west-1  |
+
+#### Falcon US-2
+
+| DNS Name                             | Service Name    | VPC Endpoint Service Name                               | AWS Region |
+|--------------------------------------|-----------------|---------------------------------------------------------|------------|
+| ts01-gyr-maverick.cloudsink.net      | Sensor Proxy    | com.amazonaws.vpce.us-west-2.vpce-svc-08a5bb05d337fd834 | us-west-2  |
+| lfodown01-gyr-maverick.cloudsink.net | Download Server | com.amazonaws.vpce.us-west-2.vpce-svc-0e11def2d8620ae74 | us-west-2  |
+
+#### Falcon EU-1
+
+| DNS Name                             | Service Name    | VPC Endpoint Service Name                                 | AWS Region   |
+|--------------------------------------|-----------------|-----------------------------------------------------------|--------------|
+| ts01-lanner-lion.cloudsink.net       | Sensor Proxy    | com.amazonaws.vpce.eu-central1.vpce-svc-0eb7b6ca4b7271385 | eu-central-1 |
+| lfodown01-lanner-lion. cloudsink.net | Download Server | com.amazonaws.vpce.eu-central1.vpce-svc-0340142b9ab8fc564 | eu-central-1 |
+
+## Quick Start Overview
 
 The templates provided in this project demonstrate how to configure this functionality. The templates create the following resources:
 
 | Resource | Description |
 |:-|:-|
-| Linux Virtual Machine | A sample workload to install the CrowdStrike Falcon Sensor into. |
+| Linux Virtual Machine | An EC2 machine where you'll install the CrowdStrike agent. |
 | Test VPC | Simulates real-world deployment scenario of workloads being protected in a project-specific VPC. |
-| CrowdStrike Shared Services VPC | Demonstrates the use of AWS PrivateLink to provide private connectivity to the CrowdStrike Cloud. |
+| CrowdStrike Shared Services VPC | Demonstrates the use of AWS PrivateLink to provide private connectivity to the CrowdStrike Cloud via a shared service VPC dedicated based on AWS best practice recommendations.|
 
-The VPCs are connected over an AWS transit gateway and a private hosted domain is created that references the VPC 
-endpoints and shared with the test VPC. 
+The VPCs are connected over an AWS Transit Gateway and enabled for DNS resolution. A Route53 private hosted zone is created for domain `cloudsink.net` and associated with the **Test VPC**. The private hosted zone contains A records that alias to the VPC endpoints associated with the Falcon Platform.
 
 For visualization purposes, here is a reference diagram showing the AWS architectural components and network traffic flow:
 
 ![PrivateLink Demo](./docs/images/privatelink-demo.png)
 
-## Configuration
+### Configuration
+
 1. Create an S3 bucket in the region where you wish to deploy the demo.
-<br/><br/>
-2. Copy the files from [https://github.com/CrowdStrike/Cloud-AWS/tree/master/aws-privatelink/s3bucket](https://github.com/CrowdStrike/Cloud-AWS/tree/master/aws-privatelink/s3bucket)  to the newly created S3 bucket. 
-<br/><br/>
+
+2. Copy the files from [https://github.com/CrowdStrike/Cloud-AWS/tree/master/aws-privatelink/s3bucket](https://github.com/CrowdStrike/Cloud-AWS/tree/master/aws-privatelink/s3bucket) to the newly created S3 bucket.
+
 ![](docs/images/s3bucket-sm.png)
+
+1. Create a CloudFormation Stack using the following template: [https://github.com/CrowdStrike/Cloud-AWS/blob/master/aws-privatelink/cloudformation/create-vpc-endpoint-r53-tgw-attachment.yaml](https://github.com/CrowdStrike/Cloud-AWS/blob/master/aws-privatelink/cloudformation/create-vpc-endpoint-r53-tgw-attachment.yaml).
 <br/><br/>
-3. Load the cloudformation template by running the CloudFormation template at [https://github.com/CrowdStrike/Cloud-AWS/blob/master/aws-privatelink/cloudformation/create-vpc-endpoint-r53-tgw-attachment.yaml](https://github.com/CrowdStrike/Cloud-AWS/blob/master/aws-privatelink/cloudformation/create-vpc-endpoint-r53-tgw-attachment.yaml).
-<br/><br/>
+
 4. Verify that the CloudFormation template has been created successfully.
-<br/><br/>
+
 ![](docs/images/cft-output-sm.png)
-<br/><br/>
-5. Connect to the linux virtual machine instance and verify that the private hosted domain has been shared with the Test VPC.
-<br/><br/>
+
+5. Connect to the Linux EC2 instance and verify that the private hosted domain has been shared with the Test VPC.
+
 ![](docs/images/dnstest-sm.png)
-<br/><br/>
+
 6. Download and install the CrowdStrike sensor.


### PR DESCRIPTION
Updated AWS PrivateLink documentation to include:

- Regional VPC endpoints
- Domain name alias for VPC endpoints
- AWS regions and Availability Zones
- Miscellaneous updates to improve clarity, grammar, and structure