### PR TITLE
Minor s3 bucket updates

### DIFF
--- a/s3-bucket-protection/demo.sh
+++ b/s3-bucket-protection/demo.sh
@@ -21,8 +21,9 @@ env_destroyed(){
     echo -e "$NC"
 }
 
+# Ensure script is executed from the s3-bucket-protection root directory
+[[ -d demo ]] && [[ -d lambda ]] || { echo -e "\nThis script should be executed from the s3-bucket-protection root directory.\n"; exit 1; }
 
-echo -e "\nThis script should be executed from the s3-bucket-protection root directory.\n"
 if [ -z "$1" ]
 then
    echo "You must specify 'up' or 'down' to run this script"


### PR DESCRIPTION
This PR:
- Fixes terraform deprecation warning about using `null_data_sources`
  - Historically, the null_data_source was typically used to construct intermediate values to re-use elsewhere in configuration. The same can now be achieved using [locals](https://www.terraform.io/docs/language/values/locals.html).
- Minor update to demo.sh to print message only if the user is in the wrong directory. Similar to gcp bucket protection script.