### PR TITLE
fix case sensitive directories

### DIFF
--- a/state-manager/ssm-distributor/agent_list.json
+++ b/state-manager/ssm-distributor/agent_list.json
@@ -13,7 +13,7 @@
 	{
       "id": "amzn2",
       "dir": "CS_AMAZON2_ARM64",
-      "file": "CS_AMAZON2_arm64.zip",
+      "file": "CS_AMAZON2_ARM64.zip",
       "name": "amazon",
       "major_version": "2",
       "minor_version": "",

--- a/systems-manager/Packaging-utilities/examples/linux-sensor-binary/agent_list.json
+++ b/systems-manager/Packaging-utilities/examples/linux-sensor-binary/agent_list.json
@@ -13,7 +13,7 @@
     {
       "id": "amzn2",
       "dir": "CS_AMAZON2_ARM64",
-      "file": "CS_AMAZON2_arm64.zip",
+      "file": "CS_AMAZON2_ARM64.zip",
       "name": "amazon",
       "major_version": "2",
       "minor_version": "",

--- a/systems-manager/Packaging-utilities/examples/linux-sensor-download/agent_list.json
+++ b/systems-manager/Packaging-utilities/examples/linux-sensor-download/agent_list.json
@@ -13,7 +13,7 @@
     {
       "id": "amzn2",
       "dir": "CS_AMAZON2_ARM64",
-      "file": "CS_AMAZON2_arm64.zip",
+      "file": "CS_AMAZON2_ARM64.zip",
       "name": "amazon",
       "major_version": "2",
       "minor_version": "",


### PR DESCRIPTION
the lowercased file name causes errors on linux due to linux being case sensitive.