### PR TITLE
Make uninstall.ps1 more useable

### DIFF
--- a/systems-manager/Packaging-utilities/examples/sensor-download/CS_WINDOWS/uninstall.ps1
+++ b/systems-manager/Packaging-utilities/examples/sensor-download/CS_WINDOWS/uninstall.ps1
@@ -30,7 +30,6 @@ if ($env:MAINTENANCE_TOKEN) {
 Write-Output "Uninstalling with arguments: $uninstallArgs"
 $uninstallProcess = Start-Process -FilePath $uninstallString -ArgumentList $uninstallArgs -PassThru -Wait
 
-Write-Output $uninstallProcess
 # Checks the exit code of the uninstall process and throws an exception if it is not 0
 if ($uninstallProcess.ExitCode -ne 0) {
   Write-Output "Failed to uninstall with exit code: $($uninstallProcess.ExitCode)"

--- a/systems-manager/Packaging-utilities/examples/sensor-download/CS_WINDOWS/uninstall.ps1
+++ b/systems-manager/Packaging-utilities/examples/sensor-download/CS_WINDOWS/uninstall.ps1
@@ -4,6 +4,9 @@ param()
 
 Write-Output 'Uninstalling Falcon Sensor...'
 
+# Configures the TLS version to use for secure connections
+[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
+
 $agentService = Get-Service -Name CSAgent -ErrorAction SilentlyContinue
 if (-not $agentService) {
   Write-Output 'CSAgent service not installed...'
@@ -17,30 +20,40 @@ $package = Get-Package -Name 'CrowdStrike Windows Sensor'
 $uninstallString = $package.Metadata['BundleCachePath']
 
 # Sets up the arguments to be passed to the uninstall executable
-$uninstallArgs = '/uninstall /quiet'
+$uninstallArgs = '/uninstall /quiet' + $env:UNINSTALLPARAMS
+
+if ($env:MAINTENANCE_TOKEN) {
+    $uninstallArgs += ' MAINTENANCE_TOKEN=' + $env:MAINTENANCE_TOKEN
+}
 
 # Starts the uninstall process and waits for it to complete
+Write-Output "Uninstalling with arguments: $uninstallArgs"
 $uninstallProcess = Start-Process -FilePath $uninstallString -ArgumentList $uninstallArgs -PassThru -Wait
 
+Write-Output $uninstallProcess
 # Checks the exit code of the uninstall process and throws an exception if it is not 0
 if ($uninstallProcess.ExitCode -ne 0) {
-  throw "Uninstaller returned exit code $($UninstallerProcess.ExitCode)"
+  Write-Output "Failed to uninstall with exit code: $($uninstallProcess.ExitCode)"
+  exit 1
 }
 
 # Retrieves the status of the CSAgent service and throws an exception if it is still running after the uninstall
 $agentService = Get-Service -Name CSAgent -ErrorAction SilentlyContinue
 if ($agentService -and $agentService.Status -eq 'Running') {
-  throw 'Service uninstall failed...'
+  Write-Output 'Uninstall process completed, but CSAgent service is still running. Uninstall failed for unknown reason...'
+  exit 1 
 }
 
 # Checks if the CrowdStrike registry key was successfully removed and throws an exception if it still exists
 if (Test-Path -Path HKLM:\System\Crowdstrike) {
-  throw 'Registry key removal failed...'
+  Write-Output "CrowdStrike registry key still exists. Uninstall failed."
+  exit 1
 }
 
 # Checks if the CrowdStrike driver was successfully removed and throws an exception if it still exists
 if (Test-Path -Path "${env:SYSTEMROOT}\System32\drivers\CrowdStrike") {
-  throw 'Driver removal failed...'
+  Write-Output "CrowdStrike driver still exists. Uninstall failed."
+  exit 1
 }
 
 Write-Output 'Successfully finished uninstall...'

--- a/systems-manager/aws-automation-doc/Local-Crowdstrike-FalconSensorDeploy.yml
+++ b/systems-manager/aws-automation-doc/Local-Crowdstrike-FalconSensorDeploy.yml
@@ -4,6 +4,14 @@ assumeRole: '{{AutomationAssumeRole}}'
 parameters:
   AWSRegion:
     type: String
+  UninstallerParams:
+    type: String
+    default: ''
+    description: (Optional) Enter CrowdStrike's uninstall time params here. For more info refer Falcon console documentation.
+  MaintenanceToken:
+    type: String
+    default: ''
+    description: (Optional) Uninstall token for windows machines
   InstallerParams:
     type: String
     default: ''
@@ -213,5 +221,7 @@ mainSteps:
           SSM_CS_INSTALLPARAMS: '{{InstallerParams}}'
           SSM_CS_AUTH_TOKEN: '{{GetAuthenticationToken.AuthToken}}'
           SSM_CS_HOST: '{{GetAuthenticationToken.ApiGatewayHost}}'
+          UNINSTALLPARAMS: '{{UninstallerParams}}'
+          MAINTENANCE_TOKEN: '{{MaintenanceToken}}'
 
 


### PR DESCRIPTION
- set powershell to use tls1.2 for windows 2016
- update error logic
- fix typo preventing exit code from printing
- add uninstall args support
- add maintenance token support