### PR TITLE
systems_manager: depreciate example

### DIFF
--- a/systems-manager/Packaging-utilities/README.md
+++ b/systems-manager/Packaging-utilities/README.md
@@ -1,3 +1,12 @@
+# :warning: This example has moved :warning:
+
+You can find the updated and maintained example in the [aws-systems-manager repository](https://github.com/CrowdStrike/aws-ssm-distributor). The new version includes numerous fixes and enhancements.
+
+Please note that the example in this folder will no longer receive maintenance and may be removed in the future.
+
+:no_entry_sign: everything below is the old example :no_entry_sign:
+---
+
 # Packaging Utilities
 
 ## Create your AWS SSM package

--- a/systems-manager/Packaging-utilities/examples/linux-sensor-binary/README.md
+++ b/systems-manager/Packaging-utilities/examples/linux-sensor-binary/README.md
@@ -1,2 +1,11 @@
+# :warning: This example has moved :warning:
+
+You can find the updated and maintained example in the [aws-systems-manager repository](https://github.com/CrowdStrike/aws-ssm-distributor). The new version includes numerous fixes and enhancements.
+
+Please note that the example in this folder will no longer receive maintenance and may be removed in the future.
+
+:no_entry_sign: everything below is the old example :no_entry_sign:
+---
+
 # Setup Instructions
 Please see the setup guide [here](https://github.com/CrowdStrike/Cloud-AWS/blob/master/systems-manager/documentation/AWS-Systems-Manager-Intro.md#option-a---creating-a-package-with-the-installer)

--- a/systems-manager/Packaging-utilities/examples/sensor-download/README.md
+++ b/systems-manager/Packaging-utilities/examples/sensor-download/README.md
@@ -1,2 +1,11 @@
+# :warning: This example has moved :warning:
+
+You can find the updated and maintained example in the [aws-systems-manager repository](https://github.com/CrowdStrike/aws-ssm-distributor). The new version includes numerous fixes and enhancements.
+
+Please note that the example in this folder will no longer receive maintenance and may be removed in the future.
+
+:no_entry_sign: everything below is the old example :no_entry_sign:
+---
+
 # Setup Instructions
 Please see the setup guide [here](https://github.com/CrowdStrike/Cloud-AWS/blob/master/systems-manager/documentation/AWS-Systems-Manager-Intro.md#option-b---creating-a-package-without-the-installer)

--- a/systems-manager/README.md
+++ b/systems-manager/README.md
@@ -1,3 +1,12 @@
+# :warning: This example has moved :warning:
+
+You can find the updated and maintained example in the [aws-systems-manager repository](https://github.com/CrowdStrike/aws-ssm-distributor). The new version includes numerous fixes and enhancements.
+
+Please note that the example in this folder will no longer receive maintenance and may be removed in the future.
+
+:no_entry_sign: everything below is the old example :no_entry_sign:
+---
+
 Description A Collection of templates and instructions for setting up and using AWS Systems Manager to install and
 uninstall the CrowdStrike Falcon agent in AWS.
 

--- a/systems-manager/documentation/AWS-Systems-Manager-Intro.md
+++ b/systems-manager/documentation/AWS-Systems-Manager-Intro.md
@@ -1,7 +1,18 @@
+# :warning: This example has moved :warning:
+
+You can find the updated and maintained example in the [aws-systems-manager repository](https://github.com/CrowdStrike/aws-ssm-distributor). The new version includes numerous fixes and enhancements.
+
+Please note that the example in this folder will no longer receive maintenance and may be removed in the future.
+
+:no_entry_sign: everything below is the old example :no_entry_sign:
+---
+
 # CrowdStrike and AWS Systems Manager
 
 **Contents**
 
+- [:warning: This example has moved :warning:](#warning-this-example-has-moved-warning)
+  - [:no\_entry\_sign: everything below is the old example :no\_entry\_sign:](#no_entry_sign-everything-below-is-the-old-example-no_entry_sign)
 - [CrowdStrike and AWS Systems Manager](#crowdstrike-and-aws-systems-manager)
   - [AWS Systems Manager](#aws-systems-manager)
     - [Monitor -- Monitor resources and applications](#monitor----monitor-resources-and-applications)


### PR DESCRIPTION
Marking this example as depreciated and adding a note to use the new example located in the aws-ssm-distributor repository.

See https://github.com/CrowdStrike/aws-ssm-distributor