### PR TITLE
add dependson condition for eip association to ec2 instance

### DIFF
--- a/aws-privatelink/cloudformation/create-vpc-endpoint-r53-tgw-attachment.yaml
+++ b/aws-privatelink/cloudformation/create-vpc-endpoint-r53-tgw-attachment.yaml
@@ -398,6 +398,7 @@ Resources:
       Domain: vpc
   AssociateControlPort:
     Type: AWS::EC2::EIPAssociation
+    DependsOn: TestInstance
     Properties:
       AllocationId: !GetAtt TestInstanceEIP.AllocationId
       NetworkInterfaceId: !Ref TestInstanceInt


### PR DESCRIPTION
Race condition can happen when associating the elastic ip to the ec2 instance if the instance is not done being created.