### PR TITLE
bug: Update routing table to point to correct CIDR

### DIFF
--- a/aws-privatelink/cloudformation/create-vpc-endpoint-r53-tgw-attachment.yaml
+++ b/aws-privatelink/cloudformation/create-vpc-endpoint-r53-tgw-attachment.yaml
@@ -247,7 +247,7 @@ Resources:
     Properties:
       RouteTableId:
         !Ref 'CSPrivLinkPrivateRouteTable1'
-      DestinationCidrBlock: 10.1.0.0/16
+      DestinationCidrBlock: !Ref TestVpcCIDR
       TransitGatewayId: !Ref 'TransitGateway'
 
   TestVPC:


### PR DESCRIPTION
Transit Gateway routing table for shared service VPC pointed to a hard-coded CIDR instead of referencing the value from the spoke VPC. This resulted in traffic routing from spoke to shared service VPC successfully but return traffic being dropped due to unknown route.