### PR TITLE
fix(s3-bucket-protection): update the existing bucket demo to use updated lambda/falconpy layer

### DIFF
--- a/s3-bucket-protection/existing.sh
+++ b/s3-bucket-protection/existing.sh
@@ -36,8 +36,9 @@ then
 	read -sp "CrowdStrike API Client SECRET: " FSECRET
     echo
     read -p "Bucket name: " BUCKET_NAME
-    rm lambda/falconpy-layer.zip >/dev/null 2>&1
-    curl -o lambda/falconpy-layer.zip https://falconpy.io/downloads/falconpy-layer.zip
+    # This demo will be using a custom version of the falconpy layer for now. - jshcodes@CrowdStrike 05.04.2023 #230
+    #rm lambda/falconpy-layer.zip >/dev/null 2>&1
+    #curl -o lambda/falconpy-layer.zip https://falconpy.io/downloads/falconpy-layer.zip
     if ! [ -f existing/.terraform.lock.hcl ]; then
         terraform -chdir=existing init
     fi


### PR DESCRIPTION
This is a follow on fix to @jshcodes last PR #231 

Adds the same changes but to the existing bucket protection demo.