### PR TITLE
add: allow existing bucket names as array

### DIFF
--- a/s3-bucket-protection/existing.sh
+++ b/s3-bucket-protection/existing.sh
@@ -35,7 +35,8 @@ then
 	echo
 	read -sp "CrowdStrike API Client SECRET: " FSECRET
     echo
-    read -p "Bucket name: " BUCKET_NAME
+    read -p "Bucket names: " BUCKET_NAMES
+    BUCKET_NAMES_LIST="\"${BUCKET_NAMES// /\",\"}\""
     # This demo will be using a custom version of the falconpy layer for now. - jshcodes@CrowdStrike 05.04.2023 #230
     #rm lambda/falconpy-layer.zip >/dev/null 2>&1
     #curl -o lambda/falconpy-layer.zip https://falconpy.io/downloads/falconpy-layer.zip
@@ -43,14 +44,15 @@ then
         terraform -chdir=existing init
     fi
 	terraform -chdir=existing apply -compact-warnings --var falcon_client_id=$FID \
-		--var falcon_client_secret=$FSECRET --var bucket_name=$BUCKET_NAME --auto-approve
+		--var falcon_client_secret=$FSECRET --var bucket_names=[$BUCKET_NAMES_LIST] --auto-approve
     all_done
 	exit 0
 fi
 if [[ "$MODE" == "remove" ]]
 then
-    read -p "Bucket name: " BUCKET_NAME
-	terraform -chdir=existing destroy -compact-warnings --var bucket_name=$BUCKET_NAME --auto-approve
+    read -p "Bucket names: " BUCKET_NAMES
+    BUCKET_NAMES_LIST="\"${BUCKET_NAMES// /\",\"}\""
+	terraform -chdir=existing destroy -compact-warnings --var bucket_names=[$BUCKET_NAMES_LIST] --auto-approve
     rm lambda/s3-bucket-protection.zip
     env_destroyed
 	exit 0

--- a/s3-bucket-protection/existing/bucket.tf
+++ b/s3-bucket-protection/existing/bucket.tf
@@ -4,7 +4,9 @@
 # }
 
 resource "aws_s3_bucket_notification" "bucket_notification" {
-  bucket = var.bucket_name
+  for_each = toset(var.bucket_names)
+
+  bucket = each.key
 
   lambda_function {
     lambda_function_arn = aws_lambda_function.func.arn

--- a/s3-bucket-protection/existing/iam.tf
+++ b/s3-bucket-protection/existing/iam.tf
@@ -1,3 +1,7 @@
+locals {
+  bucket_arns = [for bucket in data.aws_s3_bucket.bucket : "${bucket.arn}/*"]
+} 
+
 data "aws_caller_identity" "current" {}
 data "aws_iam_policy" "AdministratorAccess" {
   arn = "arn:aws:iam::aws:policy/AdministratorAccess"
@@ -37,7 +41,7 @@ data "aws_iam_policy_document" "lambda_s3_policy_document" {
           "s3:DeleteObjectVersion"
       ]
       effect = "Allow"
-      resources = ["${data.aws_s3_bucket.bucket.arn}/*"]
+      resources = local.bucket_arns
     }
 }
 data "aws_iam_policy_document" "lambda_securityhub_policy_document" {

--- a/s3-bucket-protection/existing/lambda-function.tf
+++ b/s3-bucket-protection/existing/lambda-function.tf
@@ -37,11 +37,12 @@ resource "aws_lambda_layer_version" "falconpy" {
 }
 
 resource "aws_lambda_permission" "allow_bucket" {
-  statement_id  = "AllowExecutionFromS3Bucket"
+  for_each = data.aws_s3_bucket.bucket
+  statement_id  = "AllowExecutionFrom-${each.key}"
   action        = "lambda:InvokeFunction"
   function_name = aws_lambda_function.func.arn
   principal     = "s3.amazonaws.com"
-  source_arn    = data.aws_s3_bucket.bucket.arn
+  source_arn    = each.value.arn
 }
 
 resource "aws_lambda_function" "func" {

--- a/s3-bucket-protection/existing/variables.tf
+++ b/s3-bucket-protection/existing/variables.tf
@@ -1,7 +1,7 @@
-variable "bucket_name" {
+variable "bucket_names" {
     description = "The name of the bucket that is created"
-    type = string
-    default = ""
+    type = list(string)
+    default = []
 }
 variable "lambda_execution_role_name" {
     description = "The name of the lambda execution IAM role"
@@ -71,5 +71,6 @@ variable "base_url" {
     default = "https://api.crowdstrike.com"
 }
 data "aws_s3_bucket" "bucket" {
-  bucket = var.bucket_name
+  for_each = toset(var.bucket_names)
+  bucket   = each.key
 }

--- a/s3-bucket-protection/lambda/lambda_function.py
+++ b/s3-bucket-protection/lambda/lambda_function.py
@@ -153,19 +153,19 @@ def lambda_handler(event, _):  # pylint: disable=R0912,R0914,R0915
         if result["sha256"] == upload_sha:
             if "no specific threat" in result["verdict"]:
                 # File is clean
-                returned = f"No threat found in {key}"
+                returned = f"Bucket: {bucket_name} No threat found in {key}"
                 log.info(returned)
             elif "unknown" in result["verdict"]:
                 if "error" in result:
                     # Error occurred
-                    returned = f"Scan error for {key}: {result['error']}"
+                    returned = f"Bucket: {bucket_name} Scan error for {key}: {result['error']}"
                 else:
                     # Undertermined scan failure
-                    returned = f"Unable to scan {key}"
+                    returned = f"Bucket: {bucket_name} Unable to scan {key}"
                 log.warning(returned)
             elif "malware" in result["verdict"]:
                 # Mitigation triggers from here
-                returned = f"Verdict for {key}: {result['verdict']}"
+                returned = f"Bucket: {bucket_name} Verdict for {key}: {result['verdict']}"
                 detection = {}
                 detection["sha"] = upload_sha
                 detection["bucket"] = bucket_name


### PR DESCRIPTION
Fixes #275 

This PR allows you to apply terraform code one time to scan several existing s3 buckets.

``` existing.sh ``` script will ask you to provide existing s3 bucket names in a format like below.

``` Bucket names: s3-bucket-protection-test s3-bucket-protection-test-test ``` 

